### PR TITLE
RUMM-1822 Add site parameter 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)
+
+gem "rubocop-rake", "~> 0.6.0"
+
+gem "rubocop-rspec", "~> 2.4"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)
-
-gem "rubocop-rake", "~> 0.6.0"
-
-gem "rubocop-rspec", "~> 2.4"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action is a wrapper around `datadog-ci` npm package, you can look at [`data
 
 Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plugin. Try it by cloning the repo, running `fastlane install_plugins` and `bundle exec fastlane test`.
 
-You can use `DATADOG_API_KEY` environment variable instead of `api_key` parameter in `Fastfile`.
+You can use `DATADOG_API_KEY` environment variable instead of `api_key` parameter in `Fastfile` as well as the `DATADOG_SITE` instead of the `site` parameter.
 
 ```ruby
 # upload symbols from...
@@ -41,6 +41,15 @@ end
 lane :upload_dsym_with_download_dsyms do
   download_dsyms
   upload_symbols_to_datadog(api_key: "datadog-api-key")
+end
+
+# Upload to EU site
+lane :upload_dsym_with_download_dsyms do
+  download_dsyms
+  upload_symbols_to_datadog(
+    api_key: "datadog-api-key",
+    site: 'datadoghq.eu'
+  )
 end
 ```
 

--- a/fastlane-plugin-datadog.gemspec
+++ b/fastlane-plugin-datadog.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rspec_junit_formatter')
   spec.add_development_dependency('rubocop', '1.12.1')
   spec.add_development_dependency('rubocop-performance')
+  spec.add_development_dependency('rubocop-rake')
   spec.add_development_dependency('rubocop-require_tools')
+  spec.add_development_dependency('rubocop-rspec')
   spec.add_development_dependency('simplecov')
 end

--- a/lib/fastlane/plugin/datadog/actions/upload_symbols_to_datadog.rb
+++ b/lib/fastlane/plugin/datadog/actions/upload_symbols_to_datadog.rb
@@ -5,6 +5,7 @@ module Fastlane
     class UploadSymbolsToDatadogAction < Action
       def self.run(params)
         ENV['DATADOG_API_KEY'] = params[:api_key]
+        ENV['DATADOG_SITE'] = params[:site]
         dsym_paths = params[:dsym_paths] # get array of paths
         if dsym_paths.instance_of?(String) # if a string is passed, put it in an array
           dsym_paths = [dsym_paths]
@@ -48,20 +49,35 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :api_key,
-          env_name: 'DATADOG_API_KEY',
-          description: "Datadog API Key for upload_symbols_to_datadog",
-          verify_block: proc do |value|
-            UI.user_error!("No API key for upload_symbols_to_datadog given, pass using `api_key: 'api_key'`") unless value && !value.empty?
-          end),
-          FastlaneCore::ConfigItem.new(key: :dsym_paths,
-          default_value: Actions.lane_context[SharedValues::DSYM_PATHS],
-          description: "An array of the folders and/or the zip files which contains the dSYM files",
-          type: Array),
-          FastlaneCore::ConfigItem.new(key: :dry_run,
-          description: "No upload to Datadog",
-          default_value: false,
-          is_string: false)
+          FastlaneCore::ConfigItem.new(
+            key: :api_key,
+            env_name: 'DATADOG_API_KEY',
+            description: "Datadog API Key for upload_symbols_to_datadog",
+            verify_block: proc do |value|
+              UI.user_error!("No API key for upload_symbols_to_datadog given, pass using `api_key: 'api_key'`") unless value && !value.empty?
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :site,
+            env_name: 'DATADOG_SITE',
+            default_value: 'datadoghq.com',
+            description: "Datadog site region. `datadoghq.com` by default, use `datadoghq.eu` for the EU",
+            verify_block: proc do |value|
+              UI.user_error!("`site` parameter should be 'datadoghq.com' or 'datadoghq.eu'") unless value == 'datadoghq.com' || value == 'datadoghq.eu'
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :dsym_paths,
+            default_value: Actions.lane_context[SharedValues::DSYM_PATHS],
+            description: "An array of the folders and/or the zip files which contains the dSYM files",
+            type: Array
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :dry_run,
+            description: "No upload to Datadog",
+            default_value: false,
+            is_string: false
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/datadog/actions/upload_symbols_to_datadog.rb
+++ b/lib/fastlane/plugin/datadog/actions/upload_symbols_to_datadog.rb
@@ -60,11 +60,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :site,
             env_name: 'DATADOG_SITE',
-            default_value: 'datadoghq.com',
-            description: "Datadog site region. `datadoghq.com` by default, use `datadoghq.eu` for the EU",
-            verify_block: proc do |value|
-              UI.user_error!("`site` parameter should be 'datadoghq.com' or 'datadoghq.eu'") unless value == 'datadoghq.com' || value == 'datadoghq.eu'
-            end
+            optional: true,
+            description: "Datadog site region. `datadoghq.com` by default, use `datadoghq.eu` for the EU"
           ),
           FastlaneCore::ConfigItem.new(
             key: :dsym_paths,

--- a/spec/datadog_action_spec.rb
+++ b/spec/datadog_action_spec.rb
@@ -1,89 +1,143 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "upload_symbols_to_datadog" do
+      before(:each) do
+        ENV['DATADOG_API_KEY'] = nil
+        ENV['DATADOG_SITE'] = nil
+      end
+
+      it "set env variables" do
+        dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/')).shellescape
+
+        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
+          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
+
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+            upload_symbols_to_datadog(
+              api_key: 'mock-api-key',
+              dsym_paths: '#{dsym_path}',
+              dry_run: true
+            )
+          end"
+        ).runner.execute(:test)
+
+        expect(ENV['DATADOG_API_KEY']).to eq("mock-api-key")
+        expect(ENV['DATADOG_SITE']).to eq("datadoghq.com")
+      end
+
+      it "set custom site env" do
+        dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/')).shellescape
+
+        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
+          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
+
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+            upload_symbols_to_datadog(
+              api_key: 'mock-api-key',
+              site: 'datadoghq.eu',
+              dsym_paths: '#{dsym_path}',
+              dry_run: true
+            )
+          end"
+        ).runner.execute(:test)
+
+        expect(ENV['DATADOG_SITE']).to eq("datadoghq.eu")
+      end
+
+      it "fails with wrong site" do
+        expect do
+          Fastlane::FastFile.new.parse(
+            "lane :test do
+              upload_symbols_to_datadog(
+                api_key: 'mock-api-key',
+                site: 'wrong.site',
+                dsym_paths: 'some-path',
+                dry_run: true
+              )
+            end"
+          ).runner.execute(:test)
+        end.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          "`site` parameter should be 'datadoghq.com' or 'datadoghq.eu'"
+        )
+      end
+
       it "uploads dSYM files" do
         dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/')).shellescape
-        api_key = 'mock-api-key'
 
-        command = []
-        command << 'npx @datadog/datadog-ci dsyms upload'
-        command << dsym_path
-        command << '--dry-run'
+        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
+          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
 
-        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh).with(command.join(" "))
-
-        Fastlane::FastFile.new.parse("lane :test do
-          upload_symbols_to_datadog(
-          api_key: '#{api_key}',
-          dsym_paths: '#{dsym_path}',
-          dry_run: true)
-        end").runner.execute(:test)
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+            upload_symbols_to_datadog(
+              api_key: 'mock-api-key',
+              dsym_paths: '#{dsym_path}',
+              dry_run: true
+            )
+          end"
+        ).runner.execute(:test)
       end
 
       it "uploads zip file containing dSYM files" do
         dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/Themoji.dSYM.zip')).shellescape
-        api_key = 'mock-api-key'
 
-        command = []
-        command << 'npx @datadog/datadog-ci dsyms upload'
-        command << dsym_path
-        command << '--dry-run'
+        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
+          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
 
-        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh).with(command.join(" "))
-
-        Fastlane::FastFile.new.parse("lane :test do
-          upload_symbols_to_datadog(
-          api_key: '#{api_key}',
-          dsym_paths: '#{dsym_path}',
-          dry_run: 'true')
-        end").runner.execute(:test)
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+            upload_symbols_to_datadog(
+              api_key: 'mock-api-key',
+              dsym_paths: '#{dsym_path}',
+              dry_run: 'true'
+            )
+          end"
+        ).runner.execute(:test)
       end
 
       it "uploads multiple folders" do
-        api_key = 'mock-api-key'
-
         dsym_paths = [
           File.expand_path(File.join('./spec/fixtures/dSYM1/')).shellescape,
           File.expand_path(File.join('./spec/fixtures/dSYM2/')).shellescape
         ]
-        commands = dsym_paths.map do |path|
-          cmd = []
-          cmd << 'npx @datadog/datadog-ci dsyms upload'
-          cmd << path
-          cmd << '--dry-run'
 
-          cmd
+        commands = dsym_paths.map do |path|
+          "npx @datadog/datadog-ci dsyms upload #{path} --dry-run"
         end
 
         commands.each do |cmd|
-          expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh).with(cmd.join(" "))
+          expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh).with(cmd)
         end
 
-        Fastlane::FastFile.new.parse("lane :test do
-          upload_symbols_to_datadog(
-          api_key: '#{api_key}',
-          dsym_paths: #{dsym_paths},
-          dry_run: true)
-        end").runner.execute(:test)
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+              upload_symbols_to_datadog(
+                api_key: 'mock-api-key',
+                dsym_paths: #{dsym_paths},
+                dry_run: true
+              )
+          end"
+        ).runner.execute(:test)
       end
 
       it "uses lane context to get dsym_path" do
         dsym_path = 'some-path'
-        api_key = 'mock-api-key'
 
-        command = []
-        command << 'npx @datadog/datadog-ci dsyms upload'
-        command << dsym_path
-        command << '--dry-run'
+        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
+          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
 
-        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh).with(command.join(" "))
-
-        Fastlane::FastFile.new.parse("lane :test do
-          Actions.lane_context[SharedValues::DSYM_PATHS] = ['#{dsym_path}']
-          upload_symbols_to_datadog(
-          api_key: '#{api_key}',
-          dry_run: 'true')
-        end").runner.execute(:test)
+        Fastlane::FastFile.new.parse(
+          "lane :test do
+            Actions.lane_context[SharedValues::DSYM_PATHS] = ['#{dsym_path}']
+            upload_symbols_to_datadog(
+              api_key: 'mock-api-key',
+              dry_run: 'true'
+            )
+          end"
+        ).runner.execute(:test)
       end
     end
   end

--- a/spec/datadog_action_spec.rb
+++ b/spec/datadog_action_spec.rb
@@ -6,27 +6,7 @@ describe Fastlane do
         ENV['DATADOG_SITE'] = nil
       end
 
-      it "set env variables" do
-        dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/')).shellescape
-
-        expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
-          .with("npx @datadog/datadog-ci dsyms upload #{dsym_path} --dry-run")
-
-        Fastlane::FastFile.new.parse(
-          "lane :test do
-            upload_symbols_to_datadog(
-              api_key: 'mock-api-key',
-              dsym_paths: '#{dsym_path}',
-              dry_run: true
-            )
-          end"
-        ).runner.execute(:test)
-
-        expect(ENV['DATADOG_API_KEY']).to eq("mock-api-key")
-        expect(ENV['DATADOG_SITE']).to eq("datadoghq.com")
-      end
-
-      it "set custom site env" do
+      it "set datadog-ci env variables" do
         dsym_path = File.expand_path(File.join('./spec/fixtures/dSYM/')).shellescape
 
         expect(Fastlane::Actions::UploadSymbolsToDatadogAction).to receive(:sh)
@@ -43,25 +23,8 @@ describe Fastlane do
           end"
         ).runner.execute(:test)
 
+        expect(ENV['DATADOG_API_KEY']).to eq("mock-api-key")
         expect(ENV['DATADOG_SITE']).to eq("datadoghq.eu")
-      end
-
-      it "fails with wrong site" do
-        expect do
-          Fastlane::FastFile.new.parse(
-            "lane :test do
-              upload_symbols_to_datadog(
-                api_key: 'mock-api-key',
-                site: 'wrong.site',
-                dsym_paths: 'some-path',
-                dry_run: true
-              )
-            end"
-          ).runner.execute(:test)
-        end.to raise_error(
-          FastlaneCore::Interface::FastlaneError,
-          "`site` parameter should be 'datadoghq.com' or 'datadoghq.eu'"
-        )
       end
 
       it "uploads dSYM files" do


### PR DESCRIPTION
# Datadog Site Configuration

Allow configuration of the Datadog site to upload dSYMs to. If not set, the default site will be Datadog US (`datadoghq.com`).