### PR TITLE
RUM-7084: Throw error when dSYM not found

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,8 @@ Performance/StringReplacement:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Layout/BlockAlignment:
+  Enabled: false
 Metrics/BlockLength:
   Enabled: false
 Metrics/ModuleLength:

--- a/README.md
+++ b/README.md
@@ -25,27 +25,31 @@ Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plu
 
 You can use `DATADOG_API_KEY` environment variable instead of `api_key` parameter in `Fastfile` as well as the `DATADOG_SITE` instead of the `site` parameter.
 
+To validate the paths of dSYM files, you can enable the `throw_errors` parameter to raise an error if any files are missing.
+
 ```ruby
 # upload symbols from...
-lane :upload_dsyms do
+lane :upload_dsyms do |options|
   upload_symbols_to_datadog(
     api_key: "datadog-api-key",
     dsym_paths: [
       "~/Downloads/appdSYMs.zip", # ...a zip file...
       "~/some/folder/with/dsym/files/" # ...or from a folder
-    ]
+    ],
+    dry_run: options[:dry_run],
+    throw_errors: options[:throw_errors]
   )
 end
 
 # download_dsyms action feeds dsym_paths automatically
-lane :upload_dsym_with_download_dsyms do
-  download_dsyms
+lane :upload_dsym_with_download_dsyms do |options|
+  download_dsyms options
   upload_symbols_to_datadog(api_key: "datadog-api-key")
 end
 
 # Upload to EU site
-lane :upload_dsym_with_download_dsyms do
-  download_dsyms
+lane :upload_dsym_with_download_dsyms do |options|
+  download_dsyms options
   upload_symbols_to_datadog(
     api_key: "datadog-api-key",
     site: 'datadoghq.eu'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,17 +1,19 @@
 # upload symbols from...
-lane :upload_dsyms do
+lane :upload_dsyms do |options|
   upload_symbols_to_datadog(
     api_key: "datadog-api-key",
     dsym_paths: [
       'assets/Themoji.dSYM.zip', # ...a zip file...
       'assets/Themoji/' # ...or from a folder
       # NOTE: these examples are actually empty in order to keep the repo at minimum size
-    ]
+    ],
+    dry_run: options[:dry_run],
+    throw_errors: options[:throw_errors]
   )
 end
 
 # download_dsyms action feeds dsym_paths automatically
-lane :upload_dsym_with_download_dsyms do
+lane :upload_dsym_with_download_dsyms do |options|
   app_store_connect_api_key(
     key_id: "key_id",
     issuer_id: "issuer_id",
@@ -21,5 +23,9 @@ lane :upload_dsym_with_download_dsyms do
     app_identifier: 'app.id.entifier',
     version: 'latest'
   )
-  upload_symbols_to_datadog(api_key: "datadog-api-key")
+  upload_symbols_to_datadog(
+    api_key: "datadog-api-key",
+    dry_run: options[:dry_run],
+    throw_errors: options[:throw_errors]
+  )
 end

--- a/lib/fastlane/plugin/datadog/version.rb
+++ b/lib/fastlane/plugin/datadog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Datadog
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/spec/datadog_action_spec.rb
+++ b/spec/datadog_action_spec.rb
@@ -18,7 +18,8 @@ describe Fastlane do
               api_key: 'mock-api-key',
               site: 'datadoghq.eu',
               dsym_paths: '#{dsym_path}',
-              dry_run: true
+              dry_run: true,
+              throw_errors: false
             )
           end"
         ).runner.execute(:test)
@@ -38,7 +39,8 @@ describe Fastlane do
             upload_symbols_to_datadog(
               api_key: 'mock-api-key',
               dsym_paths: '#{dsym_path}',
-              dry_run: true
+              dry_run: true,
+              throw_errors: false
             )
           end"
         ).runner.execute(:test)
@@ -55,7 +57,8 @@ describe Fastlane do
             upload_symbols_to_datadog(
               api_key: 'mock-api-key',
               dsym_paths: '#{dsym_path}',
-              dry_run: 'true'
+              dry_run: 'true',
+              throw_errors: false
             )
           end"
         ).runner.execute(:test)
@@ -80,7 +83,8 @@ describe Fastlane do
               upload_symbols_to_datadog(
                 api_key: 'mock-api-key',
                 dsym_paths: #{dsym_paths},
-                dry_run: true
+                dry_run: true,
+                throw_errors: false
               )
           end"
         ).runner.execute(:test)
@@ -97,7 +101,8 @@ describe Fastlane do
             Actions.lane_context[SharedValues::DSYM_PATHS] = ['#{dsym_path}']
             upload_symbols_to_datadog(
               api_key: 'mock-api-key',
-              dry_run: 'true'
+              dry_run: true,
+              throw_errors: false
             )
           end"
         ).runner.execute(:test)


### PR DESCRIPTION
### What and why?

This PR adds an extra validation to the `upload_symbols_to_datadog` fastlane action in order to check for valid `dSyms` paths injected in the action.

### How?

It adds an extra parameter `--throw_errors` to trigger an error everytime the `dSyms` are not found on the defined paths. It is an optional parameter, which means that the action will work as before by default.

The fastlane action can be added to a lane like the next `lane :upload_dsyms`:
```ruby
lane :upload_dsyms do |options|
  upload_symbols_to_datadog(
    api_key: "datadog-api-key",
    dsym_paths: ['dSyms/'],
    throw_errors: options[:throw_errors]
  )
end
```
To run the lane and trigger errors, just add the `throw_errors` with a `true` value flag:
`> fastlane upload_dsyms throw_errors:true`

### Additional information

It is an improvement that also mitigates the issue requested [here](https://github.com/DataDog/datadog-fastlane-plugin/issues/14).

